### PR TITLE
fix: enable SDL2 for optional sdl2 plugins & tools

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -76,6 +76,7 @@ BuildRequires:  graphviz
 BuildRequires:  sbc-devel
 BuildRequires:  libsndfile-devel
 BuildRequires:  ncurses-devel
+BuildRequires:  SDL2-devel
 
 Requires(pre):  shadow-utils
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
@@ -203,6 +204,7 @@ This package provides a PulseAudio implementation based on PipeWire
 %meson \
     -D docs=true -D man=true -D gstreamer=true -D systemd=true 		\
     -D gstreamer-device-provider=false					\
+    -D sdl2=enabled -D sndfile=enabled          \
     %{!?with_jack:-D jack=false -D pipewire-jack=false} 		\
     %{!?with_alsa:-D pipewire-alsa=false}				\
     %{?with_vulkan:-D vulkan=true}


### PR DESCRIPTION
Spec needs updating for change in pipewire build options issue [meson: Make SDL2 and libsndfile dependencies configurable](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/b17fe4aba450f48e0da498cc8de9ec766055591e).

This adds `SDL2-devel` as a build require, and sets `-D sdl2=enabled -D sndfile=enabled` meson options to allow sources using these options to make use of them.