### PR TITLE
fix: specify bluez5 codec options now they are not implicit

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -77,6 +77,7 @@ BuildRequires:  sbc-devel
 BuildRequires:  libsndfile-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  SDL2-devel
+BuildRequires:  libldac-devel
 
 Requires(pre):  shadow-utils
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
@@ -209,6 +210,9 @@ This package provides a PulseAudio implementation based on PipeWire
     -D libcamera=disabled \
     -D gstreamer-device-provider=disabled					\
     -D sdl2=enabled -D sndfile=enabled          \
+    -D bluez5-codec-aptx=disabled  \
+    -D bluez5-codec-aac=disabled  \
+    -D bluez5-codec-ldac=enabled  \
     %{!?with_jack:-D jack=disabled -D pipewire-jack=disabled} 		\
     %{!?with_alsa:-D pipewire-alsa=disabled}				\
     %{?with_vulkan:-D vulkan=enabled}


### PR DESCRIPTION
Set bluez codec meson options explicitly for [meson: Add 'feature' options to enable/disable bluetooth codecs](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/4c9af21ec6b2dcd1811ed2859ffb4fa69d8d12d6#ca9bb7eff80503c97c83505e8acea4002fd87ac6).

libldac - enabled is available in main Fedora repos.
fdk-aac - disabled, only available in rpmfusion
libopenaptx - disabled, not available (though is coming to rpmfusion)