### PR TITLE
chore: bump microversion to 24

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -1,6 +1,6 @@
 %global majorversion 0
 %global minorversion 3
-%global microversion 23
+%global microversion 24
 
 %global apiversion   0.3
 %global spaversion   0.2


### PR DESCRIPTION
Bump microversion to 24 (see commit [0.3.24](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/c81d44e8a9497899d01bcc3054b6aa845e7a066e)) otherwise nightly version is not picked up.