### PR TITLE
fix: disable wireplumber build

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -264,6 +264,7 @@ This package provides a PulseAudio implementation based on PipeWire
     -D sndfile=enabled                                                  \
     -D bluez5-codec-aptx=disabled                                       \
     -D bluez5-codec-ldac=enabled                                        \
+    -D wireplumber=disabled                                             \
     %{!?with_jack:-D pipewire-jack=disabled} 					\
     %{!?with_jackserver_plugin:-D jack=disabled} 				\
     %{?with_jack:-D jack-devel=enabled} 					\


### PR DESCRIPTION
Update to disable wireplumber build (default is auto and that will fail as the preerquisites are not installed).

