### PR TITLE
fix: disabled roc as roc-streaming not available

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -266,6 +266,7 @@ This package provides a PulseAudio implementation based on PipeWire
     -D bluez5-codec-aptx=disabled                                       \
     -D bluez5-codec-ldac=enabled                                        \
     -D wireplumber=disabled                                             \
+    -D roc=disabled                                                     \
     %{!?with_jack:-D pipewire-jack=disabled} 					\
     %{!?with_jackserver_plugin:-D jack=disabled} 				\
     %{?with_jack:-D jack-devel=enabled} 					\


### PR DESCRIPTION
Commit [meson: adds post meson setup/--reconfigure summary for auto features](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/71d39e90ed6bd8729f6ae0ab8d1bf5d2640bc3df) changes meson options handling to use roc streaming.

Add `-D roc=disabled`