### PR TITLE
fix: jack-devel option to boolean

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -286,7 +286,7 @@ This package provides a PulseAudio implementation based on PipeWire
 %endif
     %{!?with_jack:-D pipewire-jack=disabled}                            \
     %{!?with_jackserver_plugin:-D jack=disabled}                        \
-    %{?with_jack:-D jack-devel=enabled}                                 \
+    %{?with_jack:-D jack-devel=true}                                 \
     %{!?with_alsa:-D pipewire-alsa=disabled}                            \
     %{?with_vulkan:-D vulkan=enabled}
 %meson_build


### PR DESCRIPTION
Update for [[Meson] Change jack-devel option to be boolean](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/a5e3d3f7a78b3305da9632cd96a1af22f02a5293).

