### PR TITLE
fix: support media-session as subproject

### DIFF
--- a/0001-Build-media-session-from-local-tarbal.patch
+++ b/0001-Build-media-session-from-local-tarbal.patch
@@ -1,0 +1,24 @@
+	
+From 4d6d04857a257494257389cc499aea9a6fd740ee Mon Sep 17 00:00:00 2001
+From: Wim Taymans <wtaymans@redhat.com>
+Date: Thu, 21 Oct 2021 10:01:06 +0200
+Subject: [PATCH] Build media-session from local tarbal
+ 
+---
+ subprojects/media-session.wrap | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+ 
+diff --git a/subprojects/media-session.wrap b/subprojects/media-session.wrap
+index f6b4e62fb..a6249e5e1 100644
+--- a/subprojects/media-session.wrap
++++ b/subprojects/media-session.wrap
+@@ -1,4 +1,4 @@
+-[wrap-git]
+-url = https://gitlab.freedesktop.org/pipewire/media-session.git
+-revision = head
++[wrap-file]
++source_filename = media-session-0.4.0.tar.gz
++directory = media-session-0.4.0
+ 
+-- 
+2.31.1


### PR DESCRIPTION
Update to support media-session, as it is a subproject now [Remove media-session from this tree](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/1bced6b2ef300acce23c0daaeb8f4fc14095f330).

Re-order pipewire-v4l2 statements to more closely align with main fedora pipewire spec file.