### PR TITLE
fix: add pipewire-pulse man page bump media session to 0.4.1

### DIFF
--- a/0001-Build-media-session-from-local-tarbal.patch
+++ b/0001-Build-media-session-from-local-tarbal.patch
@@ -17,8 +17,8 @@ index f6b4e62fb..a6249e5e1 100644
 -url = https://gitlab.freedesktop.org/pipewire/media-session.git
 -revision = head
 +[wrap-file]
-+source_filename = media-session-0.4.0.tar.gz
-+directory = media-session-0.4.0
++source_filename = media-session-0.4.1.tar.gz
++directory = media-session-0.4.1
  
 -- 
 2.31.1

--- a/pipewire.spec
+++ b/pipewire.spec
@@ -6,7 +6,7 @@
 %global spaversion   0.2
 %global soversion    0
 %global libversion   %{soversion}.%(bash -c '((intversion = (%{minorversion} * 100) + %{microversion})); echo ${intversion}').0
-%global ms_version   0.4.0
+%global ms_version   0.4.1
 
 # https://bugzilla.redhat.com/983606
 %global _hardened_build 1
@@ -556,6 +556,7 @@ systemctl --no-reload preset --global pipewire.socket >/dev/null 2>&1 || :
 %if %{with pulse}
 %files pulseaudio
 %{_bindir}/pipewire-pulse
+%{_mandir}/man1/pipewire-pulse.1*
 %{_userunitdir}/pipewire-pulse.*
 %{_datadir}/pipewire/pipewire-pulse.conf
 %endif


### PR DESCRIPTION
Add new pipewire-pulse.1 man page [add a man page for pipewire-pulse](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/eb688a9f57bc0fc7659052428bc0528beead2e0d).

Update media-session to use 0.4.1