### PR TITLE
fix: add openssl-devel dependency

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -100,6 +100,7 @@ BuildRequires:  pulseaudio-libs-devel
 BuildRequires:  avahi-devel
 BuildRequires:  pkgconfig(webrtc-audio-processing) >= 0.2
 BuildRequires:  libusb-devel
+BuildRequires:  openssl-devel
 
 Requires(pre):  shadow-utils
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}


### PR DESCRIPTION
 Add openssl-devel dependency used in [add beginnings of RAOP protocol](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/9223fc2885e65cab6faba4f671cef3eed78f34d4).

