### PR TITLE
feat: add lilv-devel dependency for lv2-plugin support

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -1,6 +1,6 @@
 %global majorversion 0
 %global minorversion 3
-%global microversion 40
+%global microversion 41
 
 %global apiversion   0.3
 %global spaversion   0.2
@@ -100,6 +100,8 @@ BuildRequires:  pulseaudio-libs-devel
 BuildRequires:  avahi-devel
 BuildRequires:  pkgconfig(webrtc-audio-processing) >= 0.2
 BuildRequires:  libusb-devel
+BuildRequires:  readline-devel            
+BuildRequires:  lilv-devel            
 BuildRequires:  openssl-devel
 
 Requires(pre):  shadow-utils


### PR DESCRIPTION
Fix lilv dependency with support for lv2-plugins [filter-chain: add support for lv2 plugins](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/597b332666972ec2c404f854d32f1f1ac1e32b4c).