### PR TITLE
fix: include spa aec libraries

### DIFF
--- a/pipewire.spec
+++ b/pipewire.spec
@@ -468,6 +468,7 @@ systemctl --no-reload preset --global pipewire.socket >/dev/null 2>&1 || :
 %{_prefix}/lib/udev/rules.d/90-pipewire-alsa.rules
 %dir %{_libdir}/spa-%{spaversion}
 %{_libdir}/spa-%{spaversion}/alsa/
+%{_libdir}/spa-%{spaversion}/aec/
 %{_libdir}/spa-%{spaversion}/audioconvert/
 %{_libdir}/spa-%{spaversion}/audiomixer/
 %{_libdir}/spa-%{spaversion}/bluez5/


### PR DESCRIPTION
Fix include spa aec libraries in support of [module-echo-cancel: Move backends to dynamic libaries
](https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/9386c70b3a2cc2df6aabfd7b6a6bc1d7ec873bd1)